### PR TITLE
Update link to HTTP RFC specification

### DIFF
--- a/open-in-web-browser.html
+++ b/open-in-web-browser.html
@@ -781,9 +781,6 @@
             <a href="https://www.eventedmind.com/classes/how-the-web-works-7f40254c" target="_blank">How the Web Works</a> [watch]
           </li>
           <li>
-            <a href="http://www.20thingsilearned.com/en-US/what-is-the-internet/1" target="_blank">What Is the Internet? Or, "You Say Tomato, I Say TCP/IP"</a> [read]
-          </li>
-          <li>
             <a href="http://www.dontfeartheinternet.com/" target="_blank">Don’t Fear the Internet</a>
           </li>
         </ul>

--- a/open-in-web-browser.html
+++ b/open-in-web-browser.html
@@ -415,7 +415,7 @@
         <p>Most relevant specifications:</p>
         <ul>
           <li>
-            <a href="https://tools.ietf.org/html/rfc2616" target="_blank">Hypertext Transfer Protocol -- HTTP/1.1</a>
+            <a href="https://httpwg.org/specs/rfc7230.html" target="_blank">Hypertext Transfer Protocol -- HTTP/1.1</a>
           </li>
           <li>
             <a href="http://httpwg.org/specs/rfc7540.html" target="_blank">HTTP/2</a>


### PR DESCRIPTION
Previous link to HTTP/1.1 RFC was pointing to RFC 2616, which has been
obsoleted by RFC 7230. This update replaces the previous link.

Closes #3 