### PR TITLE
Update link to HTTP RFC specification

### DIFF
--- a/open-in-web-browser.html
+++ b/open-in-web-browser.html
@@ -415,7 +415,7 @@
         <p>Most relevant specifications:</p>
         <ul>
           <li>
-            <a href="https://tools.ietf.org/html/rfc2616" target="_blank">Hypertext Transfer Protocol -- HTTP/1.1</a>
+            <a href="https://httpwg.org/specs/rfc7230.html" target="_blank">Hypertext Transfer Protocol -- HTTP/1.1</a>
           </li>
           <li>
             <a href="http://httpwg.org/specs/rfc7540.html" target="_blank">HTTP/2</a>
@@ -915,7 +915,7 @@
             <a href="https://http2.github.io/" target="_blank">HTTP/2</a>
           </li>
           <li>
-            <a href="https://tools.ietf.org/html/rfc2616" target="_blank">Hypertext Transfer Protocol -- HTTP/1.1</a>
+            <a href="https://httpwg.org/specs/rfc7230.html" target="_blank">Hypertext Transfer Protocol -- HTTP/1.1</a>
           </li>
         </ul>
         <h4 id="http-docs">HTTP Docs</h4>


### PR DESCRIPTION
Previous link to HTTP/1.1 RFC was pointing to RFC 2616, which has been
obsoleted by RFC 7230. This update replaces the previous link.

#3 