### PR TITLE
Remove reference to broken link

### DIFF
--- a/open-in-web-browser.html
+++ b/open-in-web-browser.html
@@ -781,9 +781,6 @@
             <a href="https://www.eventedmind.com/classes/how-the-web-works-7f40254c" target="_blank">How the Web Works</a> [watch]
           </li>
           <li>
-            <a href="http://www.20thingsilearned.com/en-US/what-is-the-internet/1" target="_blank">What Is the Internet? Or, "You Say Tomato, I Say TCP/IP"</a> [read]
-          </li>
-          <li>
             <a href="http://www.dontfeartheinternet.com/" target="_blank">Don’t Fear the Internet</a>
           </li>
         </ul>
@@ -831,9 +828,6 @@
         </ul>
         <h4 id="how-browsers-work">How Browsers Work</h4>
         <ul>
-          <li>
-            <a href="http://www.20thingsilearned.com/en-US/foreword/1" target="_blank">20 Things I Learned About Browsers and the Web</a> [read]
-          </li>
           <li>
             <a href="http://dbaron.org/talks/2012-03-11-sxsw/master.xhtml" target="_blank">Fast CSS: How Browsers Lay Out Web Pages</a> [read]
           </li>


### PR DESCRIPTION
• The webpage http://www.20thingsilearned.com/en-US/what-is-the-internet/1 is no longer being hosted & redirects with a 301 to https://google.com

Fixes #47 